### PR TITLE
Allow users to contact support from Keycloak login page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Keycloakify Starter Devcontainer",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": true,
+      "installDockerBuildx": true,
+      "version": "latest",
+      "dockerDashComposeVersion": "none"
+    },
+    "ghcr.io/devcontainers-contrib/features/maven-sdkman:2": {
+      "version": "latest",
+      "jdkVersion": "latest",
+      "jdkDistro": "ms"
+    }
+  },
+  "postCreateCommand": "yarn install",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-# List of email addresses to present to users for contact information
-CONTACT_EMAILS=dstephenson@trihydro.com,bpayne@trihydro.com

--- a/.env
+++ b/.env
@@ -1,7 +1,2 @@
-# This .env file is used to inject environment variables into the application when 
-# running yarn storybook in development mode. Since this file is meant to be included 
-# in the repository, it should not contain sensitive information.
-
-
 # List of email addresses to present to users for contact information
-CONTACT_EMAILS=[{"name": "Daniel Stephenson", "email": "dstephenson@trihydro.com"},{"name": "Brandon Payne", "email": "bpayne@trihydro.com"}]
+CONTACT_EMAILS=dstephenson@trihydro.com,bpayne@trihydro.com

--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# List of email addresses to present to users for contact information
+CONTACT_EMAILS=dstephenson@trihydro.com,bpayne@trihydro.com

--- a/.env
+++ b/.env
@@ -1,2 +1,7 @@
+# This .env file is used to inject environment variables into the application when 
+# running yarn storybook in development mode. Since this file is meant to be included 
+# in the repository, it should not contain sensitive information.
+
+
 # List of email addresses to present to users for contact information
-CONTACT_EMAILS=dstephenson@trihydro.com,bpayne@trihydro.com
+CONTACT_EMAILS=[{"name": "Daniel Stephenson", "email": "dstephenson@trihydro.com"},{"name": "Brandon Payne", "email": "bpayne@trihydro.com"}]

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "jpo-cvmanager"]
+	path = jpo-cvmanager
+	url = https://github.com/Trihydro/jpo-cvmanager

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -204,6 +204,18 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                     </div>
                 )}
             </div>
+            <div>
+                <br />
+                <p>Can't log in? Please contact the following individuals for support.</p>
+                <ul>
+                    <li>
+                        <strong>Daniel Stephenson</strong> - <a href="mailto:dstephenson@trihydro.com">dstephenson@trihydro.com</a>
+                    </li>
+                    <li>
+                        <strong>Brandon Payne</strong> - <a href="mailto:bpayne@trihydro.com">bpayne@trihydro.com</a>
+                    </li>
+                </ul>
+            </div>
         </Template>
     );
 }

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -16,31 +16,6 @@ if (result.wasPresent) {
     console.log("my_custom_param", result.value);
 }
 
-var contact1email = "";
-var contact2email = "";
-
-const getEnvVar = (name: string): string => {
-    const value = process.env[name];
-    if (value === undefined) {
-        return "";
-    }
-    return value;
-}
-
-const setContactEmails = () => {
-    contact1email = getEnvVar("CONTACT1_EMAIL");
-    if (contact1email === "") {
-        console.error("CONTACT1_EMAIL is required");
-        return;
-    }
-    contact2email = getEnvVar("CONTACT2_EMAIL");
-    if (contact2email === "") {
-        console.error("CONTACT2_EMAIL is required");
-        return;
-    }
-}
-
-setContactEmails();
 
 export default function Login(props: PageProps<Extract<KcContext, { pageId: "login.ftl" }>, I18n>) {
     const { kcContext, i18n, doUseDefaultCss, Template, classes } = props;
@@ -231,13 +206,13 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
             </div>
             <div>
                 <br />
-                <p>Can't logaaaa in? Please contact the following individuals for support.</p>
+                <p>Can't log in? Please contact the following individuals for support.</p>
                 <ul>
                     <li>
-                        <a href={`mailto:${contact1email}`}>{contact1email}</a>
+                        <strong>Daniel Stephenson</strong> - <a href="mailto:dstephenson@trihydro.com">dstephenson@trihydro.com</a>
                     </li>
                     <li>
-                        <a href={`mailto:${contact2email}`}>{contact2email}</a>
+                        <strong>Brandon Payne</strong> - <a href="mailto:bpayne@trihydro.com">bpayne@trihydro.com</a>
                     </li>
                 </ul>
             </div>

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { useState, type FormEventHandler } from "react";
+import { JSXElementConstructor, ReactElement, ReactFragment, ReactPortal, useState, type FormEventHandler } from "react";
 import { clsx } from "keycloakify/tools/clsx";
 import { useConstCallback } from "keycloakify/tools/useConstCallback";
 import type { PageProps } from "keycloakify/login/pages/PageProps";
@@ -209,13 +209,11 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                 <br />
                 <p>Can't log in? Please contact the following individuals for support.</p>
                 <ul>
-                    {
-                        contactEmails.split(",").map((email) => (
-                            <li>
-                                <a href={`mailto:${email}`}>{email}</a>
-                            </li>
-                        ))
-                    }
+                    {JSON.parse(contactEmails).map((contact: { email: string; name: string }) => (
+                        <li key={contact.email}>
+                            <strong>{contact.name}</strong> - <a href={`mailto:${contact.email}`}>{contact.email}</a>
+                        </li>
+                    ))}
                 </ul>
             </div>
         </Template>

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -16,7 +16,31 @@ if (result.wasPresent) {
     console.log("my_custom_param", result.value);
 }
 
-var contactEmails = process.env.CONTACT_EMAILS ?? "";
+var contact1email = "";
+var contact2email = "";
+
+const getEnvVar = (name: string): string => {
+    const value = process.env[name];
+    if (value === undefined) {
+        return "";
+    }
+    return value;
+}
+
+const setContactEmails = () => {
+    contact1email = getEnvVar("CONTACT1_EMAIL");
+    if (contact1email === "") {
+        console.error("CONTACT1_EMAIL is required");
+        return;
+    }
+    contact2email = getEnvVar("CONTACT2_EMAIL");
+    if (contact2email === "") {
+        console.error("CONTACT2_EMAIL is required");
+        return;
+    }
+}
+
+setContactEmails();
 
 export default function Login(props: PageProps<Extract<KcContext, { pageId: "login.ftl" }>, I18n>) {
     const { kcContext, i18n, doUseDefaultCss, Template, classes } = props;
@@ -207,15 +231,14 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
             </div>
             <div>
                 <br />
-                <p>Can't log in? Please contact the following individuals for support.</p>
+                <p>Can't logaaaa in? Please contact the following individuals for support.</p>
                 <ul>
-                    {
-                        contactEmails.split(",").map((email) => (
-                            <li>
-                                <a href={`mailto:${email}`}>{email}</a>
-                            </li>
-                        ))
-                    }
+                    <li>
+                        <a href={`mailto:${contact1email}`}>{contact1email}</a>
+                    </li>
+                    <li>
+                        <a href={`mailto:${contact2email}`}>{contact2email}</a>
+                    </li>
                 </ul>
             </div>
         </Template>

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -16,6 +16,31 @@ if (result.wasPresent) {
     console.log("my_custom_param", result.value);
 }
 
+var contact1email = "";
+var contact2email = "";
+
+const getEnvVar = (name: string): string => {
+    const value = process.env[name];
+    if (value === undefined) {
+        return "";
+    }
+    return value;
+}
+
+const setContactEmails = () => {
+    contact1email = getEnvVar("CONTACT1_EMAIL");
+    if (contact1email === "") {
+        console.error("CONTACT1_EMAIL is required");
+        return;
+    }
+    contact2email = getEnvVar("CONTACT2_EMAIL");
+    if (contact2email === "") {
+        console.error("CONTACT2_EMAIL is required");
+        return;
+    }
+}
+
+setContactEmails();
 
 export default function Login(props: PageProps<Extract<KcContext, { pageId: "login.ftl" }>, I18n>) {
     const { kcContext, i18n, doUseDefaultCss, Template, classes } = props;
@@ -206,13 +231,13 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
             </div>
             <div>
                 <br />
-                <p>Can't log in? Please contact the following individuals for support.</p>
+                <p>Can't logaaaa in? Please contact the following individuals for support.</p>
                 <ul>
                     <li>
-                        <strong>Daniel Stephenson</strong> - <a href="mailto:dstephenson@trihydro.com">dstephenson@trihydro.com</a>
+                        <a href={`mailto:${contact1email}`}>{contact1email}</a>
                     </li>
                     <li>
-                        <strong>Brandon Payne</strong> - <a href="mailto:bpayne@trihydro.com">bpayne@trihydro.com</a>
+                        <a href={`mailto:${contact2email}`}>{contact2email}</a>
                     </li>
                 </ul>
             </div>

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -16,31 +16,7 @@ if (result.wasPresent) {
     console.log("my_custom_param", result.value);
 }
 
-var contact1email = "";
-var contact2email = "";
-
-const getEnvVar = (name: string): string => {
-    const value = process.env[name];
-    if (value === undefined) {
-        return "";
-    }
-    return value;
-}
-
-const setContactEmails = () => {
-    contact1email = getEnvVar("CONTACT1_EMAIL");
-    if (contact1email === "") {
-        console.error("CONTACT1_EMAIL is required");
-        return;
-    }
-    contact2email = getEnvVar("CONTACT2_EMAIL");
-    if (contact2email === "") {
-        console.error("CONTACT2_EMAIL is required");
-        return;
-    }
-}
-
-setContactEmails();
+var contactEmails = process.env.CONTACT_EMAILS ?? "";
 
 export default function Login(props: PageProps<Extract<KcContext, { pageId: "login.ftl" }>, I18n>) {
     const { kcContext, i18n, doUseDefaultCss, Template, classes } = props;
@@ -231,14 +207,15 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
             </div>
             <div>
                 <br />
-                <p>Can't logaaaa in? Please contact the following individuals for support.</p>
+                <p>Can't log in? Please contact the following individuals for support.</p>
                 <ul>
-                    <li>
-                        <a href={`mailto:${contact1email}`}>{contact1email}</a>
-                    </li>
-                    <li>
-                        <a href={`mailto:${contact2email}`}>{contact2email}</a>
-                    </li>
+                    {
+                        contactEmails.split(",").map((email) => (
+                            <li>
+                                <a href={`mailto:${email}`}>{email}</a>
+                            </li>
+                        ))
+                    }
                 </ul>
             </div>
         </Template>

--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -1,4 +1,4 @@
-import { JSXElementConstructor, ReactElement, ReactFragment, ReactPortal, useState, type FormEventHandler } from "react";
+import { useState, type FormEventHandler } from "react";
 import { clsx } from "keycloakify/tools/clsx";
 import { useConstCallback } from "keycloakify/tools/useConstCallback";
 import type { PageProps } from "keycloakify/login/pages/PageProps";
@@ -209,11 +209,13 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                 <br />
                 <p>Can't log in? Please contact the following individuals for support.</p>
                 <ul>
-                    {JSON.parse(contactEmails).map((contact: { email: string; name: string }) => (
-                        <li key={contact.email}>
-                            <strong>{contact.name}</strong> - <a href={`mailto:${contact.email}`}>{contact.email}</a>
-                        </li>
-                    ))}
+                    {
+                        contactEmails.split(",").map((email) => (
+                            <li>
+                                <a href={`mailto:${email}`}>{email}</a>
+                            </li>
+                        ))
+                    }
                 </ul>
             </div>
         </Template>


### PR DESCRIPTION
## Problem
There is no way for users to contact support from the Keycloak login page at this time.

## Solution
The Login page has been modified to include some mailto: links to allow users to contact support if necessary.

## Testing
This has been tested on Trihydro's fork of the jpo-cvmanager project:

![image](https://github.com/Trihydro/keycloakify-starter/assets/21204351/30c9b8ed-6a7f-45cc-874b-f8abd2494ec2)
